### PR TITLE
Archive action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Mercury/
 *.err
 *.mh
 tags
+bower
+src/bower

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Peter Wang <novalazy@gmail.com>
+Stian Soiland-Reyes <stain@apache.org>

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,8 @@
 Bower 0.8 (????-??-??)
 ======================
 * Look up email addresses using notmuch address
-* Archive a thread/message with '.' (mark read, remove "inbox" tag)
+* Archive a thread/message with 'a' (undo with 'A')
+* Add to addressbook key changed to '@'
 
 Bower 0.7 (2016-03-28)
 ======================

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Bower 0.8 (????-??-??)
+======================
+* Look up email addresses using notmuch address
+* Archive a thread/message with '.' (mark read, remove "inbox" tag)
+
 Bower 0.7 (2016-03-28)
 ======================
 This release requires notmuch 0.16 or above (notmuch 0.19+ is recommended)

--- a/README.md
+++ b/README.md
@@ -111,12 +111,13 @@ The keys are:
     e               reply to everyone
     L               reply to list
     R               recall postponed message
-    a               add to addressbook
+    @               add to addressbook
     /, ?            search for string within results
     n               skip to next search result
     N               toggle unread tag on current thread
     F               toggle flagged tag on current thread
-    .               archive thread (tag -unread -inbox)
+    a               archive thread (tag -unread -inbox)
+    A               un-archive thread (tag +inbox)
     d               set deleted tag on current thread
     u               unset deleted tag on current thread
     +, -            add/remove arbitrary tags
@@ -191,7 +192,8 @@ This view pages through an entire thread.  The keys are:
     N               toggle 'unread' tag on current message
     ^R              remove 'unread' tag on preceding messages
     F               toggle 'flagged' tag on current message
-    .               archive message (tag -unread -inbox)
+    a               archive message (tag -unread -inbox)
+    A               un-archive message (tag +inbox)
     d               add 'deleted' tag on current message
     u               remove 'deleted' tag on current message
     +, -            add/remove arbitrary tags
@@ -206,7 +208,7 @@ This view pages through an entire thread.  The keys are:
     B               resend message to another address ("bounce")
     E               use current message as a template for a new message
     R               recall postponed message
-    a               add to addressbook
+    @               add to addressbook
 
     v               highlight next visible attachment or URL or folded text
     V               highlight next visible attachment or top of message
@@ -219,6 +221,8 @@ This view pages through an entire thread.  The keys are:
 
     i, q            return to index
     I               return to index, removing 'unread' tag on all messages
+    Q               return to index, archiving all messages (-unread -inbox)
+
 
 Tag updates are only applied when returning to the index.
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The keys are:
     n               skip to next search result
     N               toggle unread tag on current thread
     F               toggle flagged tag on current thread
+    .               archive message (tag -unread -inbox)
     d               set deleted tag on current thread
     u               unset deleted tag on current thread
     +, -            add/remove arbitrary tags
@@ -305,4 +306,3 @@ Author
 Peter Wang <novalazy@gmail.com>
 
 Feel free to contact me with feedback or suggestions.
-

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The keys are:
     n               skip to next search result
     N               toggle unread tag on current thread
     F               toggle flagged tag on current thread
-    .               archive message (tag -unread -inbox)
+    .               archive thread (tag -unread -inbox)
     d               set deleted tag on current thread
     u               unset deleted tag on current thread
     +, -            add/remove arbitrary tags
@@ -191,6 +191,7 @@ This view pages through an entire thread.  The keys are:
     N               toggle 'unread' tag on current message
     ^R              remove 'unread' tag on preceding messages
     F               toggle 'flagged' tag on current message
+    .               archive message (tag -unread -inbox)
     d               add 'deleted' tag on current message
     u               remove 'deleted' tag on current message
     +, -            add/remove arbitrary tags

--- a/src/index_view.m
+++ b/src/index_view.m
@@ -1136,10 +1136,13 @@ unset_deleted(Line0, Line, TagDeltas) :-
     Line = Line0 ^ i_std_tags ^ deleted := not_deleted,
     TagDeltas = [tag_delta("-deleted")].
 
-:- pred archive(index_line::in, index_line::out, list(tag_delta)::out) is det.
+:- pred archive(index_line::in, index_line::out, list(tag_delta)::out) is semidet.
 
 archive(Line0, Line, TagDeltas) :-
-    Line = Line0 ^ i_tags := not_deleted,
+    Line = Line0 ^ i_std_tags ^ unread := read,
+    TagSet0 = Line0 ^ i_tags,
+    set.difference(TagSet0, set.make_singleton_set(tag("inbox")), TagSet),
+    TagSet \= TagSet0,
     TagDeltas = [tag_delta("-inbox"), tag_delta("-unread")].
 
 

--- a/src/index_view.m
+++ b/src/index_view.m
@@ -708,13 +708,13 @@ key_binding_char('r', start_reply(direct_reply)).
 key_binding_char('e', start_reply(group_reply)).
 key_binding_char('L', start_reply(list_reply)).
 key_binding_char('R', start_recall).
-key_binding_char('a', addressbook_add).
+key_binding_char('@', addressbook_add).
 key_binding_char('/', prompt_internal_search(dir_forward)).
 key_binding_char('?', prompt_internal_search(dir_reverse)).
 key_binding_char('n', skip_to_internal_search).
 key_binding_char('N', toggle_unread).
 key_binding_char('F', toggle_flagged).
-key_binding_char('.', archive).
+key_binding_char('a', archive).
 key_binding_char('d', set_deleted).
 key_binding_char('u', unset_deleted).
 key_binding_char('+', prompt_tag("+")).

--- a/src/index_view.m
+++ b/src/index_view.m
@@ -1136,13 +1136,12 @@ unset_deleted(Line0, Line, TagDeltas) :-
     Line = Line0 ^ i_std_tags ^ deleted := not_deleted,
     TagDeltas = [tag_delta("-deleted")].
 
-:- pred archive(index_line::in, index_line::out, list(tag_delta)::out) is semidet.
+:- pred archive(index_line::in, index_line::out, list(tag_delta)::out) is det.
 
 archive(Line0, Line, TagDeltas) :-
-    Line = Line0 ^ i_std_tags ^ unread := read,
     TagSet0 = Line0 ^ i_tags,
-    set.difference(TagSet0, set.make_singleton_set(tag("inbox")), TagSet),
-    TagSet \= TagSet0,
+    set.delete_list([tag("inbox"), tag("unread")], TagSet0, TagSet),
+    set_index_line_tags(TagSet, Line0, Line),
     TagDeltas = [tag_delta("-inbox"), tag_delta("-unread")].
 
 

--- a/src/index_view.m
+++ b/src/index_view.m
@@ -111,6 +111,7 @@
     ;       toggle_unread
     ;       toggle_flagged
     ;       archive
+    ;       unarchive
     ;       set_deleted
     ;       unset_deleted
     ;       prompt_tag(string)
@@ -134,6 +135,7 @@
     ;       toggle_unread
     ;       toggle_flagged
     ;       archive
+    ;       unarchive
     ;       set_deleted
     ;       unset_deleted
     ;       prompt_tag(string)
@@ -450,6 +452,10 @@ index_loop_no_draw(Screen, !.IndexInfo, !IO) :-
         modify_tag_cursor_line(archive, Screen, !IndexInfo, !IO),
         index_loop(Screen, !.IndexInfo, !IO)
     ;
+        Action = unarchive,
+        modify_tag_cursor_line(unarchive, Screen, !IndexInfo, !IO),
+        index_loop(Screen, !.IndexInfo, !IO)
+    ;
         Action = set_deleted,
         modify_tag_cursor_line(set_deleted, Screen, !IndexInfo, !IO),
         index_loop(Screen, !.IndexInfo, !IO)
@@ -630,6 +636,10 @@ index_view_input(Screen, KeyCode, MessageUpdate, Action, !IndexInfo) :-
             MessageUpdate = no_change,
             Action = archive
         ;
+            Binding = unarchive,
+            MessageUpdate = no_change,
+            Action = unarchive
+        ;
             Binding = set_deleted,
             MessageUpdate = no_change,
             Action = set_deleted
@@ -715,6 +725,7 @@ key_binding_char('n', skip_to_internal_search).
 key_binding_char('N', toggle_unread).
 key_binding_char('F', toggle_flagged).
 key_binding_char('a', archive).
+key_binding_char('A', unarchive).
 key_binding_char('d', set_deleted).
 key_binding_char('u', unset_deleted).
 key_binding_char('+', prompt_tag("+")).
@@ -1143,6 +1154,14 @@ archive(Line0, Line, TagDeltas) :-
     set.delete_list([tag("inbox"), tag("unread")], TagSet0, TagSet),
     set_index_line_tags(TagSet, Line0, Line),
     TagDeltas = [tag_delta("-inbox"), tag_delta("-unread")].
+
+:- pred unarchive(index_line::in, index_line::out, list(tag_delta)::out) is det.
+
+unarchive(Line0, Line, TagDeltas) :-
+    TagSet0 = Line0 ^ i_tags,
+    set.insert(tag("inbox"), TagSet0, TagSet),
+    set_index_line_tags(TagSet, Line0, Line),
+    TagDeltas = [tag_delta("+inbox")].
 
 
 %-----------------------------------------------------------------------------%

--- a/src/index_view.m
+++ b/src/index_view.m
@@ -110,6 +110,7 @@
     ;       skip_to_internal_search
     ;       toggle_unread
     ;       toggle_flagged
+    ;       archive
     ;       set_deleted
     ;       unset_deleted
     ;       prompt_tag(string)
@@ -132,6 +133,7 @@
     ;       prompt_internal_search(search_direction)
     ;       toggle_unread
     ;       toggle_flagged
+    ;       archive
     ;       set_deleted
     ;       unset_deleted
     ;       prompt_tag(string)
@@ -444,6 +446,10 @@ index_loop_no_draw(Screen, !.IndexInfo, !IO) :-
         modify_tag_cursor_line(toggle_flagged, Screen, !IndexInfo, !IO),
         index_loop(Screen, !.IndexInfo, !IO)
     ;
+        Action = archive,
+        modify_tag_cursor_line(archive, Screen, !IndexInfo, !IO),
+        index_loop(Screen, !.IndexInfo, !IO)
+    ;
         Action = set_deleted,
         modify_tag_cursor_line(set_deleted, Screen, !IndexInfo, !IO),
         index_loop(Screen, !.IndexInfo, !IO)
@@ -620,6 +626,10 @@ index_view_input(Screen, KeyCode, MessageUpdate, Action, !IndexInfo) :-
             MessageUpdate = no_change,
             Action = toggle_flagged
         ;
+            Binding = archive,
+            MessageUpdate = no_change,
+            Action = archive
+        ;
             Binding = set_deleted,
             MessageUpdate = no_change,
             Action = set_deleted
@@ -704,6 +714,7 @@ key_binding_char('?', prompt_internal_search(dir_reverse)).
 key_binding_char('n', skip_to_internal_search).
 key_binding_char('N', toggle_unread).
 key_binding_char('F', toggle_flagged).
+key_binding_char('.', archive).
 key_binding_char('d', set_deleted).
 key_binding_char('u', unset_deleted).
 key_binding_char('+', prompt_tag("+")).
@@ -1078,6 +1089,7 @@ modify_tag_cursor_line(ModifyPred, Screen, !Info, !IO) :-
     ),
     update_message(Screen, MessageUpdate, !IO).
 
+
 :- pred toggle_unread(index_line::in, index_line::out, tag_delta::out) is det.
 
 toggle_unread(Line0, Line, TagDelta) :-
@@ -1123,6 +1135,13 @@ set_deleted(Line0, Line, TagDelta) :-
 unset_deleted(Line0, Line, TagDelta) :-
     Line = Line0 ^ i_std_tags ^ deleted := not_deleted,
     TagDelta = tag_delta("-deleted").
+
+:- pred archive(index_line::in, index_line::out, tag_delta::out) is det.
+
+archive(Line0, Line, TagDelta) :-
+    Line = Line0 ^ i_std_tags ^ deleted := not_deleted,
+    TagDelta = tag_delta("-inbox").
+
 
 %-----------------------------------------------------------------------------%
 

--- a/src/index_view.m
+++ b/src/index_view.m
@@ -1063,7 +1063,7 @@ line_matches_internal_search(Search, Line) :-
 
 %-----------------------------------------------------------------------------%
 
-:- pred modify_tag_cursor_line(pred(index_line, index_line, tag_delta),
+:- pred modify_tag_cursor_line(pred(index_line, index_line, list(tag_delta)),
     screen, index_info, index_info, io, io).
 :- mode modify_tag_cursor_line(in(pred(in, out, out) is det),
     in, in, out, di, uo) is det.
@@ -1074,9 +1074,9 @@ modify_tag_cursor_line(ModifyPred, Screen, !Info, !IO) :-
     Scrollable0 = !.Info ^ i_scrollable,
     ( get_cursor_line(Scrollable0, _Cursor0, CursorLine0) ->
         ThreadId = CursorLine0 ^ i_id,
-        ( ModifyPred(CursorLine0, CursorLine, TagDelta) ->
+        ( ModifyPred(CursorLine0, CursorLine, TagDeltas) ->
             Config = !.Info ^ i_config,
-            async_tag_threads(Config, [TagDelta], [ThreadId], !IO),
+            async_tag_threads(Config, TagDeltas, [ThreadId], !IO),
             set_cursor_line(CursorLine, Scrollable0, Scrollable),
             !Info ^ i_scrollable := Scrollable,
             move_cursor(Screen, 1, _MessageUpdate, !Info),
@@ -1090,33 +1090,33 @@ modify_tag_cursor_line(ModifyPred, Screen, !Info, !IO) :-
     update_message(Screen, MessageUpdate, !IO).
 
 
-:- pred toggle_unread(index_line::in, index_line::out, tag_delta::out) is det.
+:- pred toggle_unread(index_line::in, index_line::out, list(tag_delta)::out) is det.
 
-toggle_unread(Line0, Line, TagDelta) :-
+toggle_unread(Line0, Line, TagDeltas) :-
     Unread0 = Line0 ^ i_std_tags ^ unread,
     (
         Unread0 = unread,
-        TagDelta = tag_delta("-unread"),
+        TagDeltas = [tag_delta("-unread")],
         Unread = read
     ;
         Unread0 = read,
-        TagDelta = tag_delta("+unread"),
+        TagDeltas = [tag_delta("+unread")],
         Unread = unread
     ),
     Line = Line0 ^ i_std_tags ^ unread := Unread.
 
-:- pred toggle_flagged(index_line::in, index_line::out, tag_delta::out)
+:- pred toggle_flagged(index_line::in, index_line::out, list(tag_delta)::out)
     is semidet.
 
-toggle_flagged(Line0, Line, TagDelta) :-
+toggle_flagged(Line0, Line, TagDeltas) :-
     Flagged0 = Line0 ^ i_std_tags ^ flagged,
     (
         Flagged0 = flagged,
-        TagDelta = tag_delta("-flagged"),
+        TagDeltas = [tag_delta("-flagged")],
         Flagged = unflagged
     ;
         Flagged0 = unflagged,
-        TagDelta = tag_delta("+flagged"),
+        TagDeltas = [tag_delta("+flagged")],
         Flagged = flagged,
         % Refuse to flag multiple messages.
         NumMessages = Line0 ^ i_total,
@@ -1124,23 +1124,23 @@ toggle_flagged(Line0, Line, TagDelta) :-
     ),
     Line = Line0 ^ i_std_tags ^ flagged := Flagged.
 
-:- pred set_deleted(index_line::in, index_line::out, tag_delta::out) is det.
+:- pred set_deleted(index_line::in, index_line::out, list(tag_delta)::out) is det.
 
-set_deleted(Line0, Line, TagDelta) :-
+set_deleted(Line0, Line, TagDeltas) :-
     Line = Line0 ^ i_std_tags ^ deleted := deleted,
-    TagDelta = tag_delta("+deleted").
+    TagDeltas = [tag_delta("+deleted")].
 
-:- pred unset_deleted(index_line::in, index_line::out, tag_delta::out) is det.
+:- pred unset_deleted(index_line::in, index_line::out, list(tag_delta)::out) is det.
 
-unset_deleted(Line0, Line, TagDelta) :-
+unset_deleted(Line0, Line, TagDeltas) :-
     Line = Line0 ^ i_std_tags ^ deleted := not_deleted,
-    TagDelta = tag_delta("-deleted").
+    TagDeltas = [tag_delta("-deleted")].
 
-:- pred archive(index_line::in, index_line::out, tag_delta::out) is det.
+:- pred archive(index_line::in, index_line::out, list(tag_delta)::out) is det.
 
-archive(Line0, Line, TagDelta) :-
-    Line = Line0 ^ i_std_tags ^ deleted := not_deleted,
-    TagDelta = tag_delta("-inbox").
+archive(Line0, Line, TagDeltas) :-
+    Line = Line0 ^ i_tags := not_deleted,
+    TagDeltas = [tag_delta("-inbox"), tag_delta("-unread")].
 
 
 %-----------------------------------------------------------------------------%

--- a/src/thread_pager.m
+++ b/src/thread_pager.m
@@ -911,6 +911,12 @@ thread_pager_input(Key, Action, MessageUpdate, !Info) :-
         next_message(MessageUpdate, !Info),
         Action = continue
     ;
+        Key = char('.')
+    ->
+        archive(!Info),
+        next_message(MessageUpdate, !Info),
+        Action = continue
+    ;
         Key = char('d')
     ->
         toggle_deleted(deleted, !Info),
@@ -1306,6 +1312,22 @@ toggle_unread(!Info) :-
     ;
         true
     ).
+
+:- pred archive(thread_pager_info::in, thread_pager_info::out) is det.
+
+archive(!Info) :-
+    Scrollable0 = !.Info ^ tp_scrollable,
+    ( get_cursor_line(Scrollable0, _Cursor, Line0) ->
+        TagSet0 = Line0 ^ tp_curr_tags,
+        set.delete_list([tag("inbox"), tag("unread")], TagSet0, TagSet),
+        Line1 = Line0 ^ tp_curr_tags := TagSet,
+        Line = Line1 ^ tp_std_tags ^ unread := read,
+        set_cursor_line(Line, Scrollable0, Scrollable),
+        !Info ^ tp_scrollable := Scrollable
+    ;
+        true
+    ).
+
 
 :- pred toggle_flagged(thread_pager_info::in, thread_pager_info::out) is det.
 

--- a/src/thread_pager.m
+++ b/src/thread_pager.m
@@ -1064,7 +1064,7 @@ thread_pager_input(Key, Action, MessageUpdate, !Info) :-
     ->
         edit_as_template(!.Info, Action, MessageUpdate)
     ;
-        Key = char('a')
+        Key = char('@')
     ->
         Action = addressbook_add,
         MessageUpdate = no_change

--- a/src/thread_pager.m
+++ b/src/thread_pager.m
@@ -917,6 +917,12 @@ thread_pager_input(Key, Action, MessageUpdate, !Info) :-
         next_message(MessageUpdate, !Info),
         Action = continue
     ;
+        Key = char('A')
+    ->
+        unarchive(!Info),
+        next_message(MessageUpdate, !Info),
+        Action = continue
+    ;
         Key = char('d')
     ->
         toggle_deleted(deleted, !Info),
@@ -1323,6 +1329,20 @@ archive(!Info) :-
         Line1 = Line0 ^ tp_curr_tags := TagSet,
         Line = Line1 ^ tp_std_tags ^ unread := read,
         set_cursor_line(Line, Scrollable0, Scrollable),
+        !Info ^ tp_scrollable := Scrollable
+    ;
+        true
+    ).
+
+:- pred unarchive(thread_pager_info::in, thread_pager_info::out) is det.
+
+unarchive(!Info) :-
+    Scrollable0 = !.Info ^ tp_scrollable,
+    ( get_cursor_line(Scrollable0, _Cursor, Line0) ->
+        TagSet0 = Line0 ^ tp_curr_tags,
+        set.insert(tag("inbox"), TagSet0, TagSet),
+        Line1 = Line0 ^ tp_curr_tags := TagSet,
+        set_cursor_line(Line1, Scrollable0, Scrollable),
         !Info ^ tp_scrollable := Scrollable
     ;
         true

--- a/src/thread_pager.m
+++ b/src/thread_pager.m
@@ -911,7 +911,7 @@ thread_pager_input(Key, Action, MessageUpdate, !Info) :-
         next_message(MessageUpdate, !Info),
         Action = continue
     ;
-        Key = char('.')
+        Key = char('a')
     ->
         archive(!Info),
         next_message(MessageUpdate, !Info),

--- a/src/thread_pager.m
+++ b/src/thread_pager.m
@@ -1045,6 +1045,13 @@ thread_pager_input(Key, Action, MessageUpdate, !Info) :-
         Action = leave,
         MessageUpdate = clear_message
     ;
+        Key = char('Q')
+    ->
+        archive_all(!Info),
+        Action = leave,
+        MessageUpdate = clear_message
+    ;
+
         Key = char('r')
     ->
         reply(!.Info, direct_reply, Action, MessageUpdate)
@@ -1283,6 +1290,21 @@ mark_all_read(!Info) :-
     Scrollable0 = !.Info ^ tp_scrollable,
     scrollable.map_lines(set_line_read, Scrollable0, Scrollable),
     !Info ^ tp_scrollable := Scrollable.
+
+:- pred archive_all(thread_pager_info::in, thread_pager_info::out) is det.
+
+archive_all(!Info) :-
+    Scrollable0 = !.Info ^ tp_scrollable,
+    scrollable.map_lines(archive_line, Scrollable0, Scrollable),
+    !Info ^ tp_scrollable := Scrollable.
+
+:- pred archive_line(thread_line::in, thread_line::out) is det.
+
+archive_line(!Line) :-
+    Tags0 = !.Line ^ tp_curr_tags,
+    set.delete_list([tag("unread"), tag("inbox")], Tags0, Tags),
+    !Line ^ tp_curr_tags := Tags,
+    !Line ^ tp_std_tags ^ unread := read.
 
 :- pred set_line_read(thread_line::in, thread_line::out) is det.
 


### PR DESCRIPTION
A quick proposal for an "Archive" function.

If you push `.` on a message in index view. It should:

- [x] Remove the tag `-inbox` from thread
- [x] Remove the tag `-unread` from thread
- [x] Refresh the tag listing of line
- [x] Go to next line


This is similar to "Toggle unread", but is useful in particular when using `bower tag:inbox`, as compatible with the archiving function of other notmuch clients.

I'm afraid I'm quite new to Mercury so this pull request is just a start - I didn't manage to do multiple `TagDelta`s at once, and for some reason the display is not updated unless you click `=` - I only managed 

Thanks for an excellent mail client with such good threading - really archiving is the only feature I seem to be missing!