### PR TITLE
make_man: get path to awk from /usr/bin/env

### DIFF
--- a/make_man
+++ b/make_man
@@ -1,4 +1,4 @@
-#!/usr/bin/awk -f
+#!/usr/bin/env awk -f
 
 BEGIN {
     output = 1;


### PR DESCRIPTION
This should improve portability on systems which don't have their binaries in `/usr/bin`.

Example for real world usage: I'm currently packaging `bower` for `Nix`, the Purely Functional Package Manager. `Nix` doesn't store any binaries in `/usr/bin/` besides `env`. With this patch, bower builds correctly.

On any other supported platform this shouldn't make a difference, afaik.

OT: thanks for this niece piece of software. Looks like this is going to be my new MUA.