### PR TITLE
hack: replace tabs with spaces in Subject header

### DIFF
--- a/src/callout.m
+++ b/src/callout.m
@@ -252,7 +252,7 @@ parse_header(Key, unesc_string(Value), !Headers) :-
         !Headers ^ h_bcc := header_value(Value)
     ; Key = "Subject" ->
         % notmuch should provide the decoded value.
-        !Headers ^ h_subject := decoded_unstructured(Value)
+        !Headers ^ h_subject := decoded_unstructured(string.replace_all(Value, "\t", " "))
     ; Key = "Reply-To" ->
         !Headers ^ h_replyto := header_value(Value)
     ; Key = "References" ->
@@ -499,7 +499,7 @@ parse_thread(Json, Thread) :-
     ->
         TagSet = set.from_list(Tags),
         Thread = thread(thread_id(Id), timestamp(float(Timestamp)), Authors,
-            Subject, TagSet, Matched, Total)
+            string.replace_all(Subject, "\t", " "), TagSet, Matched, Total)
     ;
         notmuch_json_error
     ).

--- a/src/message_file.m
+++ b/src/message_file.m
@@ -67,7 +67,7 @@ read_headers(String, Pos0, Pos, !Headers) :-
         % Other headers should be decoded as well.
         ( strcase_equal(Name, "Subject") ->
             decode_unstructured(RawValue, Decoded),
-            Value = decoded_unstructured(Decoded)
+            Value = decoded_unstructured(string.replace_all(Decoded, "\t", " "))
         ;
             Value = header_value(RawValue)
         ),


### PR DESCRIPTION
Questionable, perhaps.

Some mailiers seem to incorrectly wrap subject messages
(I think that's what I chased this down to?) which results
in unsightly hard tabs in subject messages.

This patch adds a visual-only workaround that simply replaces
these tabs with a single space which is significantly less jarring.

The issue may be present elsewhere in my stack,
thoughts/feedback welcome.
Until the underlying issue is resolved
(which it may not ever be, if in widely used mailing software)
this produces a nicer experience, with "cost" of no longer properly
showing actual hard tabs in subjects -- which personally is quite
alright :).