### PR TITLE
Hide tags starting with .

### DIFF
--- a/src/tags.m
+++ b/src/tags.m
@@ -89,6 +89,9 @@ nondisplay_tag(tag("sent")).
 nondisplay_tag(tag("signed")).
 nondisplay_tag(tag("unread")).
 
+nondisplay_tag(tag(String)) :-
+    string.remove_prefix(".", String, _).
+
 %-----------------------------------------------------------------------------%
 
 get_standard_tags(Tags, StdTags, DisplayTagsWidth) :-


### PR DESCRIPTION
I've seen this being done in practice, to hide 'maintenance' tags for
stuff like spam filtering or other metadata.