### PR TITLE
Add thread_ordering to config options

### DIFF
--- a/bower.conf.sample
+++ b/bower.conf.sample
@@ -136,6 +136,12 @@
     #
   ; wrap_width =
 
+    # Default thread ordering when viewing messages. May be "flat" or
+    # "threaded". Default: "threaded". The ordering can be toggled by
+    # pressing 'O' while viewing a thread of messages.
+    #
+  ; thread_ordering = threaded
+
 #-----------------------------------------------------------------------------#
 
 [crypto]


### PR DESCRIPTION
Although bower provides both threaded and flat views of a thread, the
default that appears when I open a new thread had been hardcoded to
be the threaded view. Since that makes some of my threads run off the
right side of my screen, I found myself almost automatically pressing
'O' after opening a message to view. This commit adds a config option
to customize the default view while retaining the current behaviour
if the option is not set.