### PR TITLE
Use B for "edit Bcc" so it doesn't conflict with pager

### DIFF
--- a/src/compose.m
+++ b/src/compose.m
@@ -776,7 +776,7 @@ staging_screen(Screen, !.StagingInfo, !.AttachInfo, !.PagerInfo, Transition,
     ; KeyCode = char('c') ->
         edit_header(Screen, cc, !StagingInfo, !CryptoInfo, !IO),
         Action = continue
-    ; KeyCode = char('b') ->
+    ; KeyCode = char('B') ->
         edit_header(Screen, bcc, !StagingInfo, !CryptoInfo, !IO),
         Action = continue
     ; KeyCode = char('s') ->
@@ -1754,7 +1754,7 @@ draw_sep_bar(Screen, yes(Panel), Attrs, !IO) :-
     get_cols(Screen, Cols, !IO),
     erase(Screen, Panel, !IO),
     draw(Screen, Panel, Attrs ^ c_status ^ bar,
-        "-- (ftcbsr) edit fields; (E)ncrypt, (S)ign; " ++
+        "-- (ftcBsr) edit fields; (E)ncrypt, (S)ign; " ++
         "(a)ttach, (d)etach, media (T)ype ", !IO),
     hline(Screen, Panel, '-', Cols, !IO).
 


### PR DESCRIPTION
The 'b' keybinding for Bcc in the compose screen conflicts with my
naturalised expectation that 'b' would be page up. Switching the
Bcc binding to uppercase 'B' is a suggestion. It would make things
more natural for me, but it might be an annoyance to others.

This is just a suggestion, of course, but it would finally save me
from accidentally opening the Bcc prompt I have been using bower
for some years now and I still can't seem to remember that 'b'
doesn't work in compose.