### PR TITLE
Increase max thread pane size after a certain point

### DIFF
--- a/src/thread_pager.m
+++ b/src/thread_pager.m
@@ -458,13 +458,18 @@ compute_num_rows(Rows, Scrollable, NumThreadRows, NumPagerRows) :-
     ExtraLines = SepLine + 2,
     Y0 = int.max(1, (Rows - ExtraLines) // 3),
     Y1 = int.min(Y0, NumThreadLines),
-    Y2 = int.min(Y1, max_thread_lines),
+    Y2 = int.min(Y1, max_thread_lines(Rows)),
     NumThreadRows = Y2,
     NumPagerRows = int.max(0, Rows - NumThreadRows - SepLine).
 
-:- func max_thread_lines = int.
+:- func max_thread_lines(int) = int.
 
-max_thread_lines = 8.
+max_thread_lines(TotalRows) = MaxRows :-
+    (
+        if TotalRows < 40
+        then MaxRows = 8
+        else MaxRows = TotalRows/5
+    ).
 
 :- pred append_threaded_messages(tm::in, list(message)::in,
     list(thread_line)::out, io::di, io::uo) is det.


### PR DESCRIPTION
This is a proposal to solve the thread pane display on hidpi
screens. Cf. <https://github.com/wangp/bower/issues/60>. It
will use the previous maximum of 8 rows for the thread pane
for terminal sizes of up to 40 rows. For larger terminals it
will use 1/5 of the terminal size as the maximum. As it happens,
8/40 = 1/5, which ensures a seamless switch between the two.
Switching back to relative size at a certain point removes all
hard limits on the maximum thread pane size.