### PR TITLE
Pull request for search_both_directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ The keys are:
     z               toggle authors column
 
     /, ?            search for string within results
-    n               skip to next search result
+    n               skip to next search result (forward)
+    N               skip to next search result (reverse)
 
     U               toggle 'unread' tag on current thread
     F               toggle 'flagged' tag on current thread
@@ -180,7 +181,8 @@ This view pages through an entire thread.  The keys are:
     =               refresh search results
 
     /, ?            search for string
-    n               skip to next search result
+    n               skip to next search result (forward)
+    N               skip to next search result (reverse)
 
     J               mark current message read and go to next message
     K               mark current message read and go to previous message

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The keys are:
     /, ?            search for string within results
     n               skip to next search result
 
-    N               toggle 'unread' tag on current thread
+    U               toggle 'unread' tag on current thread
     F               toggle 'flagged' tag on current thread
     a               toggle 'inbox', 'unread' tags on current thread (archive)
     d               set 'deleted' tag on current thread
@@ -184,7 +184,7 @@ This view pages through an entire thread.  The keys are:
 
     J               mark current message read and go to next message
     K               mark current message read and go to previous message
-    N               toggle 'unread' tag on current message
+    U               toggle 'unread' tag on current message
     ^R              remove 'unread' tag on preceding messages
     F               toggle 'flagged' tag on current message
     a               toggle 'inbox', 'unread' tags on current message (archive)

--- a/src/index_view.m
+++ b/src/index_view.m
@@ -705,7 +705,7 @@ key_binding_char('@', addressbook_add).
 key_binding_char('/', prompt_internal_search(dir_forward)).
 key_binding_char('?', prompt_internal_search(dir_reverse)).
 key_binding_char('n', skip_to_internal_search).
-key_binding_char('N', toggle_unread).
+key_binding_char('U', toggle_unread).
 key_binding_char('a', toggle_archive).
 key_binding_char('F', toggle_flagged).
 key_binding_char('d', set_deleted).

--- a/src/index_view.m
+++ b/src/index_view.m
@@ -72,7 +72,6 @@
                 i_next_poll_time    :: maybe(timestamp),
                 i_poll_count        :: int,
                 i_internal_search   :: maybe(string),
-                i_internal_search_dir :: search_direction,
                 i_show_authors      :: show_authors,
                 i_common_history    :: common_history
             ).
@@ -118,7 +117,7 @@
     ;       start_reply(reply_kind)
     ;       addressbook_add
     ;       prompt_internal_search(search_direction)
-    ;       skip_to_internal_search
+    ;       skip_to_internal_search(search_direction)
     ;       toggle_unread
     ;       toggle_archive
     ;       toggle_flagged
@@ -213,7 +212,7 @@ open_index(Config, NotmuchConfig, Crypto, Screen, SearchString,
     MaybeSearch = no,
     IndexInfo = index_info(Config, Crypto, Scrollable, SearchString,
         SearchTokens, SearchTime, NextPollTime, PollCount, MaybeSearch,
-        dir_forward, show_authors, !.CommonHistory),
+        show_authors, !.CommonHistory),
     index_loop(Screen, redraw, IndexInfo, !IO).
 
 :- pred search_terms_with_progress(prog_config::in, screen::in,
@@ -598,8 +597,9 @@ index_view_input(NumRows, KeyCode, MessageUpdate, Action, !IndexInfo) :-
             MessageUpdate = no_change,
             Action = prompt_internal_search(SearchDir)
         ;
-            Binding = skip_to_internal_search,
-            skip_to_internal_search(NumRows, MessageUpdate, !IndexInfo),
+            Binding = skip_to_internal_search(Direction),
+            skip_to_internal_search(NumRows, Direction, MessageUpdate,
+                !IndexInfo),
             Action = continue
         ;
             Binding = toggle_unread,
@@ -704,7 +704,8 @@ key_binding_char('R', start_recall).
 key_binding_char('@', addressbook_add).
 key_binding_char('/', prompt_internal_search(dir_forward)).
 key_binding_char('?', prompt_internal_search(dir_reverse)).
-key_binding_char('n', skip_to_internal_search).
+key_binding_char('n', skip_to_internal_search(dir_forward)).
+key_binding_char('N', skip_to_internal_search(dir_reverse)).
 key_binding_char('U', toggle_unread).
 key_binding_char('a', toggle_archive).
 key_binding_char('F', toggle_flagged).
@@ -971,24 +972,22 @@ prompt_internal_search(Screen, SearchDir, !Info, !IO) :-
         ;
             add_history_nodup(Search, History0, History),
             !Info ^ i_internal_search := yes(Search),
-            !Info ^ i_internal_search_dir := SearchDir,
             !Info ^ i_common_history ^ ch_internal_search_history := History,
             get_main_rows(Screen, NumRows, !IO),
-            skip_to_internal_search(NumRows, MessageUpdate, !Info),
+            skip_to_internal_search(NumRows, SearchDir, MessageUpdate, !Info),
             update_message(Screen, MessageUpdate, !IO)
         )
     ;
         Return = no
     ).
 
-:- pred skip_to_internal_search(int::in, message_update::out,
-    index_info::in, index_info::out) is det.
+:- pred skip_to_internal_search(int::in, search_direction::in,
+    message_update::out, index_info::in, index_info::out) is det.
 
-skip_to_internal_search(NumRows, MessageUpdate, !Info) :-
+skip_to_internal_search(NumRows, SearchDir, MessageUpdate, !Info) :-
     MaybeSearch = !.Info ^ i_internal_search,
     (
         MaybeSearch = yes(Search),
-        SearchDir = !.Info ^ i_internal_search_dir,
         Scrollable0 = !.Info ^ i_scrollable,
         ( get_cursor(Scrollable0, Cursor0) ->
             (

--- a/src/thread_pager.m
+++ b/src/thread_pager.m
@@ -1027,7 +1027,7 @@ thread_pager_input(Key, Action, MessageUpdate, !Info) :-
         next_message(MessageUpdate, !Info),
         Action = continue
     ;
-        Key = char('N')
+        Key = char('U')
     ->
         toggle_unread(!Info),
         next_message(MessageUpdate, !Info),

--- a/src/thread_pager.m
+++ b/src/thread_pager.m
@@ -101,7 +101,6 @@
                 tp_index_poll_count :: int,
 
                 tp_search           :: maybe(string),
-                tp_search_dir       :: search_direction,
                 tp_common_history   :: common_history,
                 tp_added_messages   :: int
             ).
@@ -203,7 +202,7 @@ open_thread_pager(Config, Crypto, Screen, ThreadId, IncludeTags,
         Ordering, Scrollable, NumThreadRows, PagerInfo, NumPagerRows,
         RefreshTime, NextPollTime, ThreadPollCount,
         IndexPollString, IndexPollCount,
-        MaybeSearch, dir_forward, CommonHistory0, AddedMessages0),
+        MaybeSearch, CommonHistory0, AddedMessages0),
 
     (
         ParseResult = ok,
@@ -230,7 +229,7 @@ reopen_thread_pager(Screen, KeepCached, !Info, !IO) :-
         Scrollable0, _NumThreadRows0, Pager0, _NumPagerRows0,
         _RefreshTime0, _NextPollTime0, _ThreadPollCount0,
         _IndexPollString, _IndexPollCount,
-        _Search, _SearchDir, _CommonHistory, _AddedMessages),
+        _Search, _CommonHistory, _AddedMessages),
 
     (
         KeepCached = yes,
@@ -1135,7 +1134,12 @@ thread_pager_input(Key, Action, MessageUpdate, !Info) :-
     ;
         Key = char('n')
     ->
-        skip_to_search(continue_search, MessageUpdate, !Info),
+        skip_to_search(continue_search, dir_forward, MessageUpdate, !Info),
+        Action = continue
+    ;
+        Key = char('N')
+    ->
+        skip_to_search(continue_search, dir_reverse, MessageUpdate, !Info),
         Action = continue
     ;
         Key = char('O')
@@ -2345,25 +2349,23 @@ prompt_search(Screen, SearchDir, !Info, !IO) :-
         ;
             add_history_nodup(Search, History0, History),
             !Info ^ tp_search := yes(Search),
-            !Info ^ tp_search_dir := SearchDir,
             !Info ^ tp_common_history ^ ch_internal_search_history := History,
-            skip_to_search(new_search, MessageUpdate, !Info),
+            skip_to_search(new_search, SearchDir, MessageUpdate, !Info),
             update_message(Screen, MessageUpdate, !IO)
         )
     ;
         Return = no
     ).
 
-:- pred skip_to_search(search_kind::in, message_update::out,
-    thread_pager_info::in, thread_pager_info::out) is det.
+:- pred skip_to_search(search_kind::in, search_direction::in,
+    message_update::out, thread_pager_info::in, thread_pager_info::out) is det.
 
-skip_to_search(SearchKind, MessageUpdate, !Info) :-
+skip_to_search(SearchKind, SearchDir, MessageUpdate, !Info) :-
     MaybeSearch = !.Info ^ tp_search,
     (
         MaybeSearch = yes(Search),
         Pager0 = !.Info ^ tp_pager,
         NumRows = !.Info ^ tp_num_pager_rows,
-        SearchDir = !.Info ^ tp_search_dir,
         pager.skip_to_search(NumRows, SearchKind, Search, SearchDir,
             MessageUpdate, Pager0, Pager),
         !Info ^ tp_pager := Pager,


### PR DESCRIPTION
## Use 'U' rather than 'N' for toggle unread

As discussed in <https://github.com/wangp/bower/issues/70>.

## Use 'N' for next search result reverse direction

This commit removes the information about the initial search direction from thread pager and index view infos. It does also bind 'n' to next search result forward and 'N' to next search result reverse (which might be the previous search result in some cases). I personally find these bindings rather convenient, but am open to discuss them, of course.

I realise that this is a little different from how most programs handle the 'n' and 'N' keys. Most programs use 'n' for *continue search in the direction it was started* and 'N' for *search in the other direction than the one specified while starting the search*. The only other program I know of that uses the keybindings proposed here is <https://github.com/martanne/vis> (which also happens to be my text editor of choice, so I may be biassed). Simply using 'n' for search forward and 'N' for search reverse and ignoring the initial search direction makes the implementation more straightforward, however, since it requires less state. I also find it easier to use myself as I don't have to remember the initial search direction either. As mentioned, this may be personal preference, of course.