### PR TITLE
A first try for the two issues mentioned in <https://github.com/wangp/bower/issues/58#issuecomment-695754442>.

### DIFF
--- a/src/compose.m
+++ b/src/compose.m
@@ -933,6 +933,8 @@ staging_screen(Screen, MaybeKey, !.StagingInfo, !.AttachInfo, !.PagerInfo,
             update_message(Screen, MessageUpdate0, !IO),
             Action = continue
         )
+    ; KeyCode = char('=') ->
+        Action = recreate(clear_message)
     ;
         ( KeyCode = char('j')
         ; KeyCode = code(curs.key_down)

--- a/src/compose.m
+++ b/src/compose.m
@@ -163,6 +163,7 @@
 :- type staging_screen_action
     --->    continue
     ;       resize(message_update)
+    ;       recreate(message_update)
     ;       edit
     ;       press_key_to_delete(string)
     ;       leave(sent, message_update).
@@ -926,7 +927,7 @@ staging_screen(Screen, MaybeKey, !.StagingInfo, !.AttachInfo, !.PagerInfo,
         toggle_alt_html(MessageUpdate0, NeedsResize, !StagingInfo, !IO),
         (
             NeedsResize = yes,
-            Action = resize(MessageUpdate0)
+            Action = recreate(MessageUpdate0)
         ;
             NeedsResize = no,
             update_message(Screen, MessageUpdate0, !IO),
@@ -1042,7 +1043,14 @@ staging_screen(Screen, MaybeKey, !.StagingInfo, !.AttachInfo, !.PagerInfo,
             !.PagerInfo, Transition, !CryptoInfo, !History, !IO)
     ;
         Action = resize(DeferredMessageUpdate),
-        resize_staging_screen(Screen, !.StagingInfo, !PagerInfo, !IO),
+        resize_staging_screen(Screen, !.StagingInfo, resize, !PagerInfo, !IO),
+        update_message(Screen, DeferredMessageUpdate, !IO),
+        staging_screen(Screen, no, !.StagingInfo, !.AttachInfo, !.PagerInfo,
+            Transition, !CryptoInfo, !History, !IO)
+    ;
+        Action = recreate(DeferredMessageUpdate),
+        resize_staging_screen(Screen, !.StagingInfo, recreate, !PagerInfo,
+            !IO),
         update_message(Screen, DeferredMessageUpdate, !IO),
         staging_screen(Screen, no, !.StagingInfo, !.AttachInfo, !.PagerInfo,
             Transition, !CryptoInfo, !History, !IO)
@@ -1078,10 +1086,11 @@ convert_pager_action(PagerAction, Action) :-
         Action = press_key_to_delete(FileName)
     ).
 
-:- pred resize_staging_screen(screen::in, staging_info::in,
+:- pred resize_staging_screen(screen::in, staging_info::in, resize_type::in,
     pager_info::in, pager_info::out, io::di, io::uo) is det.
 
-resize_staging_screen(Screen, StagingInfo, PagerInfo0, PagerInfo, !IO) :-
+resize_staging_screen(Screen, StagingInfo, PartsChanged, PagerInfo0,
+        PagerInfo, !IO) :-
     recreate_screen_for_resize(Screen, !IO),
     get_cols(Screen, Cols, !IO),
     get_main_panels(Screen, MainPanels, !IO),
@@ -1092,7 +1101,8 @@ resize_staging_screen(Screen, StagingInfo, PagerInfo0, PagerInfo, !IO) :-
     Text = StagingInfo ^ si_text,
     MaybeAltHtml = StagingInfo ^ si_alt_html,
     setup_pager_for_staging(Config, Cols, Text, MaybeAltHtml,
-        retain_pager_pos(PagerInfo0, NumPagerRows), PagerInfo, !IO).
+        retain_pager_pos(PagerInfo0, NumPagerRows, PartsChanged),
+        PagerInfo, !IO).
 
 %-----------------------------------------------------------------------------%
 

--- a/src/pager.m
+++ b/src/pager.m
@@ -823,9 +823,10 @@ wrap_text(Text) = text(Text).
 %-----------------------------------------------------------------------------%
 
 :- pred make_staging_tree(prog_config::in, int::in, string::in,
-    maybe(string)::in, tree::out, counter::out, bool::out, io::di, io::uo).
+    maybe(string)::in, bool::in, tree::out, counter::out, bool::out,
+    io::di, io::uo).
 
-make_staging_tree(Config, Cols, Text, MaybeAltHtml, Tree, Counter,
+make_staging_tree(Config, Cols, Text, MaybeAltHtml, ShowHtml, Tree, Counter,
         LastBlank0, !IO) :-
     TextPlainPart = part(message_id(""), no, mime_type.text_plain, no,
         yes(content_disposition("inline")), text(Text), no, no, no,
@@ -846,9 +847,14 @@ make_staging_tree(Config, Cols, Text, MaybeAltHtml, Tree, Counter,
         TextHtmlPart = part(message_id(""), no, mime_type.text_html, no,
             yes(content_disposition("inline")), text(HtmlContent), no, no, no,
             is_decrypted),
+        (
+            ShowHtml = yes, OrderedParts = [TextHtmlPart, TextPlainPart]
+        ;
+            ShowHtml = no, OrderedParts = [TextPlainPart, TextHtmlPart]
+        ),
         MixedPart = part(message_id(""), no, mime_type.multipart_alternative,
             no, yes(content_disposition("inline")), subparts(not_encrypted, [],
-            [TextPlainPart, TextHtmlPart]), no, no, no, is_decrypted),
+            OrderedParts), no, no, no, is_decrypted),
         Part = MixedPart,
         LastBlank0 = no
     ),
@@ -859,11 +865,11 @@ make_staging_tree(Config, Cols, Text, MaybeAltHtml, Tree, Counter,
     Tree = node(NodeId, [BodyTree0, Separators], no).
 
 :- pred new_info_for_staging(prog_config::in, int::in, string::in,
-    maybe(string)::in, pager_info::out, io::di, io::uo).
+    maybe(string)::in, bool::in, pager_info::out, io::di, io::uo).
 
-new_info_for_staging(Config, Cols, Text, MaybeAltHtml, Info, !IO) :-
-        make_staging_tree(Config, Cols, Text, MaybeAltHtml, Tree, Counter,
-            LastBlank0, !IO),
+new_info_for_staging(Config, Cols, Text, MaybeAltHtml, ShowHtml, Info, !IO) :-
+        make_staging_tree(Config, Cols, Text, MaybeAltHtml, ShowHtml,
+            Tree, Counter, LastBlank0, !IO),
         Flattened = flatten(Tree, LastBlank0),
         Scrollable = scrollable.init(Flattened),
         make_extents(Flattened, Extents),
@@ -874,12 +880,13 @@ setup_pager_for_staging(Config, Cols, Text, MaybeAltHtml, RetainPagerPos,
         Info, !IO) :-
     (
         RetainPagerPos = new_pager,
-        new_info_for_staging(Config, Cols, Text, MaybeAltHtml, Info, !IO)
+        new_info_for_staging(Config, Cols, Text, MaybeAltHtml, no, Info, !IO)
     ;
         RetainPagerPos = retain_pager_pos(OldPager, _NumRows, ResizeType),
         (
             ResizeType = recreate,
-            new_info_for_staging(Config, Cols, Text, MaybeAltHtml, Info, !IO)
+            new_info_for_staging(Config, Cols, Text, MaybeAltHtml, yes,
+                Info, !IO)
         ;
             ResizeType = resize,
             Info = OldPager


### PR DESCRIPTION
## Directly show html in compose when toggled manually

Works pretty well, IMO.

## Retain old message pager in compose for resize

Unfortunately, I lost line re-wrapping in this implementation. I believe resizing without line re-wrapping but retaining the pager position, expanded and collapsed parts and such is still better than not retaining any of it, but of course this solution is not ideal.