### PR TITLE
 Markspam

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The keys are:
     U               toggle 'unread' tag on current thread
     F               toggle 'flagged' tag on current thread
     a               toggle 'inbox', 'unread' tags on current thread (archive)
-    S               toggle 'spam' tag on current thread
+    $               toggle 'spam' tag on current thread
     d               set 'deleted' tag on current thread
     u               unset 'deleted' tag on current thread
     +, -            add/remove arbitrary tags
@@ -196,7 +196,7 @@ This view pages through an entire thread.  The keys are:
     ^R              remove 'unread' tag on preceding messages
     F               toggle 'flagged' tag on current message
     a               toggle 'inbox', 'unread' tags on current message (archive)
-    S               toggle 'spam' tag on current message
+    $               toggle 'spam' tag on current message
     d               add 'deleted' tag on current message
     u               remove 'deleted' tag on current message
     +, -            add/remove arbitrary tags

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The keys are:
     U               toggle 'unread' tag on current thread
     F               toggle 'flagged' tag on current thread
     a               toggle 'inbox', 'unread' tags on current thread (archive)
+    S               toggle 'spam' tag on current thread
     d               set 'deleted' tag on current thread
     u               unset 'deleted' tag on current thread
     +, -            add/remove arbitrary tags
@@ -195,6 +196,7 @@ This view pages through an entire thread.  The keys are:
     ^R              remove 'unread' tag on preceding messages
     F               toggle 'flagged' tag on current message
     a               toggle 'inbox', 'unread' tags on current message (archive)
+    S               toggle 'spam' tag on current message
     d               add 'deleted' tag on current message
     u               remove 'deleted' tag on current message
     +, -            add/remove arbitrary tags

--- a/src/index_view.m
+++ b/src/index_view.m
@@ -1360,7 +1360,7 @@ bulk_tag(Screen, Done, !Info, !IO) :-
     Lines0 = get_lines_list(Scrollable0),
     ( any_selected_line(Lines0) ->
         Prompt = "Action: (d)elete, (u)ndelete, (N) toggle unread, " ++
-            "(') mark read, (S)pam, (+/-) change tags",
+            "(') mark read, ($)pam, (+/-) change tags",
         get_keycode_blocking_handle_resize(Screen, set_prompt(Prompt), KeyCode,
             !Info, !IO),
         ( KeyCode = char('-') ->

--- a/src/index_view.m
+++ b/src/index_view.m
@@ -123,6 +123,7 @@
     ;       skip_to_internal_search(rel_search_direction)
     ;       toggle_unread
     ;       toggle_archive
+    ;       toggle_spam
     ;       toggle_flagged
     ;       set_deleted
     ;       unset_deleted
@@ -149,6 +150,7 @@
     ;       prompt_internal_search(search_direction)
     ;       toggle_unread
     ;       toggle_archive
+    ;       toggle_spam
     ;       toggle_flagged
     ;       set_deleted
     ;       unset_deleted
@@ -500,6 +502,10 @@ index_loop(Screen, OnEntry, !.IndexInfo, !IO) :-
         modify_tag_cursor_line(toggle_archive, Screen, !IndexInfo, !IO),
         index_loop(Screen, redraw, !.IndexInfo, !IO)
     ;
+        Action = toggle_spam,
+        modify_tag_cursor_line(toggle_spam, Screen, !IndexInfo, !IO),
+        index_loop(Screen, redraw, !.IndexInfo, !IO)
+    ;
         Action = toggle_flagged,
         modify_tag_cursor_line(toggle_flagged, Screen, !IndexInfo, !IO),
         index_loop(Screen, redraw, !.IndexInfo, !IO)
@@ -639,6 +645,10 @@ index_view_input(NumRows, KeyCode, MessageUpdate, Action, !IndexInfo) :-
             MessageUpdate = no_change,
             Action = toggle_archive
         ;
+            Binding = toggle_spam,
+            MessageUpdate = no_change,
+            Action = toggle_spam
+        ;
             Binding = toggle_flagged,
             MessageUpdate = no_change,
             Action = toggle_flagged
@@ -742,6 +752,7 @@ key_binding_char('N', skip_to_internal_search(opposite_dir)).
 key_binding_char('U', toggle_unread).
 key_binding_char('a', toggle_archive).
 key_binding_char('F', toggle_flagged).
+key_binding_char('S', toggle_spam).
 key_binding_char('d', set_deleted).
 key_binding_char('u', unset_deleted).
 key_binding_char('+', prompt_tag("+")).
@@ -1157,6 +1168,23 @@ toggle_archive(Line0, Line, TagDeltas) :-
     ;
         set.insert(tag("inbox"), TagSet0, TagSet),
         TagDeltas = [tag_delta("+inbox")]
+    ),
+    set_tags(TagSet, Line0, Line).
+
+:- pred toggle_spam(index_line::in, index_line::out, list(tag_delta)::out)
+    is det.
+
+toggle_spam(Line0, Line, TagDeltas) :-
+    TagSet0 = Line0 ^ i_tags,
+    (
+        ( set.contains(TagSet0, tag("spam"))
+        )
+    ->
+        set.delete_list([tag("spam")], TagSet0, TagSet),
+        TagDeltas = [tag_delta("-spam")]
+    ;
+        set.insert(tag("spam"), TagSet0, TagSet),
+        TagDeltas = [tag_delta("+spam")]
     ),
     set_tags(TagSet, Line0, Line).
 

--- a/src/index_view.m
+++ b/src/index_view.m
@@ -1369,7 +1369,7 @@ bulk_tag(Screen, Done, !Info, !IO) :-
     Lines0 = get_lines_list(Scrollable0),
     ( any_selected_line(Lines0) ->
         Prompt = "Action: (d)elete, (u)ndelete, (N) toggle unread, " ++
-            "(') mark read, (+/-) change tags",
+            "(') mark read, (S)pam, (+/-) change tags",
         get_keycode_blocking_handle_resize(Screen, set_prompt(Prompt), KeyCode,
             !Info, !IO),
         ( KeyCode = char('-') ->
@@ -1387,6 +1387,13 @@ bulk_tag(Screen, Done, !Info, !IO) :-
         ; KeyCode = char('d') ->
             TagDeltas = [tag_delta("+deleted")],
             AddTags = set.make_singleton_set(tag("deleted")),
+            RemoveTags = set.init,
+            bulk_tag_changes(TagDeltas, AddTags, RemoveTags, MessageUpdate,
+                !Info, !IO),
+            Done = yes
+        ; KeyCode = char('S') ->
+            TagDeltas = [tag_delta("+spam")],
+            AddTags = set.make_singleton_set(tag("spam")),
             RemoveTags = set.init,
             bulk_tag_changes(TagDeltas, AddTags, RemoveTags, MessageUpdate,
                 !Info, !IO),

--- a/src/thread_pager.m
+++ b/src/thread_pager.m
@@ -1675,7 +1675,7 @@ bulk_tag(Screen, Done, !Info, !IO) :-
     Lines0 = get_lines_list(Scrollable0),
     ( any_selected_line(Lines0) ->
         Prompt = "Action: (d)elete, (u)ndelete, (N) toggle unread, " ++
-            "(') mark read, (+/-) change tags",
+            "(') mark read, (S)pam, (+/-) change tags",
         get_keycode_blocking_handle_resize(Screen, set_prompt(Prompt), KeyCode,
             !Info, !IO),
         ( KeyCode = char('-') ->
@@ -1692,6 +1692,11 @@ bulk_tag(Screen, Done, !Info, !IO) :-
             Done = yes
         ; KeyCode = char('d') ->
             AddTags = set.make_singleton_set(tag("deleted")),
+            RemoveTags = set.init,
+            bulk_tag_changes(AddTags, RemoveTags, MessageUpdate, !Info, !IO),
+            Done = yes
+        ; KeyCode = char('S') ->
+            AddTags = set.make_singleton_set(tag("spam")),
             RemoveTags = set.init,
             bulk_tag_changes(AddTags, RemoveTags, MessageUpdate, !Info, !IO),
             Done = yes

--- a/src/thread_pager.m
+++ b/src/thread_pager.m
@@ -1654,7 +1654,7 @@ bulk_tag(Screen, Done, !Info, !IO) :-
     Lines0 = get_lines_list(Scrollable0),
     ( any_selected_line(Lines0) ->
         Prompt = "Action: (d)elete, (u)ndelete, (N) toggle unread, " ++
-            "(') mark read, (S)pam, (+/-) change tags",
+            "(') mark read, ($)pam, (+/-) change tags",
         get_keycode_blocking_handle_resize(Screen, set_prompt(Prompt), KeyCode,
             !Info, !IO),
         ( KeyCode = char('-') ->


### PR DESCRIPTION
Mark messages as spam and unsets unread with '$'.  Updated per comments from #79. Addresses #78.