### PR TITLE
Add Guix Alternative Installation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,7 @@ To generate a man page, run:
 
 This will produce `bower.1` for installation into your `man` search path.
 
-Alternative Installation
-========================
-
-The [guixrus channel](https://git.sr.ht/~whereiseveryone/guixrus) also provides bower.
-
-After [adding guixrus](https://git.sr.ht/~whereiseveryone/guixrus#permanent) to your [channels.scm](https://guix.gnu.org/manual/en/html_node/Using-a-Custom-Guix-Channel.html) run the following:
-
-`guix install bower-guixrus`
+Packages are also available in the [AUR](https://aur.archlinux.org/packages/?K=bower), [Gentoo](https://packages.gentoo.org/packages/mail-client/bower), [GuixRUS](https://git.sr.ht/~whereiseveryone/guixrus), and [Nixpkgs](https://search.nixos.org/packages?query=notmuch%2Dbower).
 
 
 Configuration

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ To generate a man page, run:
 
 This will produce `bower.1` for installation into your `man` search path.
 
+Alternative Installation
+========================
+
+The [guixrus channel](https://git.sr.ht/~whereiseveryone/guixrus) also provides bower.
+
+After [adding guixrus](https://git.sr.ht/~whereiseveryone/guixrus#permanent) to your [channels.scm](https://guix.gnu.org/manual/en/html_node/Using-a-Custom-Guix-Channel.html) run the following:
+
+`guix install bower-guixrus`
+
 
 Configuration
 =============


### PR DESCRIPTION
Hi,

I packaged bower 0.13 for guix and put it in a pre-release channel called [GuixRUS](https://git.sr.ht/~whereiseveryone/guixrus/commit/389dc1db8379d59d50041284b7fe3f59a28f9c23) that I maintain with some other guix upstream contributors.

All commits are gpg signed by the maintainers.

Next, I'll send a patch upstream and wait for review and merge.

In the meantime, the `GuixRUS` channel is available. We'll also be offering a public binary server (substitute server in guix jargon) for the channel (TBA).

I [also maintain](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/applications/networking/mailreaders/notmuch-bower/default.nix#L34) the nix package for bower. 

Tests are enabled for the guix package but not for the nix package currently.

I'll look to enabling tests for the nix bower package next.

```
 _________________________________________ 
/ 3B1D 7F19 E36B B60C 0F5B 2CA9 A52A A2B4 \
\ 77B6 DD35                               /
 ----------------------------------------- 
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```