### PR TITLE
# Allow manual overrides of the date header field

### DIFF
--- a/src/compose.crypto.m
+++ b/src/compose.crypto.m
@@ -97,7 +97,7 @@ maintain_encrypt_keys(ParsedHeaders, !CryptoInfo, !IO) :-
     io::di, io::uo) is det.
 
 maintain_encrypt_keys_map(Crypto, ParsedHeaders, !EncryptKeys, !IO) :-
-    ParsedHeaders = parsed_headers(From, To, Cc, Bcc, _ReplyTo),
+    ParsedHeaders = parsed_headers(From, To, Cc, Bcc, _ReplyTo, _Date),
     Addresses = From ++ To ++ Cc ++ Bcc,
     solutions(addr_specs(Addresses), AddrSpecs),
     list.foldl2(maintain_encrypt_key(Crypto), AddrSpecs, !EncryptKeys, !IO).
@@ -140,7 +140,7 @@ maintain_sign_keys(ParsedHeaders, !CryptoInfo, !IO) :-
     io::di, io::uo) is det.
 
 maintain_sign_keys_map(Crypto, ParsedHeaders, !SignKeys, !IO) :-
-    ParsedHeaders = parsed_headers(From, _To, _Cc, _Bcc, _ReplyTo),
+    ParsedHeaders = parsed_headers(From, _To, _Cc, _Bcc, _ReplyTo, _Date),
     solutions(addr_specs(From), AddrSpecs),
     list.foldl2(maintain_sign_key(Crypto), AddrSpecs, !SignKeys, !IO).
 
@@ -249,7 +249,7 @@ is_valid_userid_matching_email(Email, IgnoreCase, UserId) :-
 get_encrypt_keys(CryptoInfo, ParsedHeaders, EncryptForWhom, SelectedKeys,
         Missing, LeakedBccs) :-
     EncryptKeys = CryptoInfo ^ ci_encrypt_keys,
-    ParsedHeaders = parsed_headers(From, To, Cc, Bcc, _ReplyTo),
+    ParsedHeaders = parsed_headers(From, To, Cc, Bcc, _ReplyTo, _Date),
     (
         EncryptForWhom = from_only,
         Addresses = From
@@ -275,7 +275,7 @@ get_encrypt_keys(CryptoInfo, ParsedHeaders, EncryptForWhom, SelectedKeys,
 
 get_sign_keys(CryptoInfo, ParsedHeaders, SelectedKeys) :-
     SignKeys = CryptoInfo ^ ci_sign_keys,
-    ParsedHeaders = parsed_headers(From, _To, _Cc, _Bcc, _ReplyTo),
+    ParsedHeaders = parsed_headers(From, _To, _Cc, _Bcc, _ReplyTo, _Date),
     solutions(addr_specs(From), AddrSpecs),
     list.foldl2(get_key(SignKeys), AddrSpecs,
         [], RevSelectedKeys, [], _RevMissing),

--- a/src/compose.m
+++ b/src/compose.m
@@ -141,7 +141,8 @@
                 ph_to           :: address_list,
                 ph_cc           :: address_list,
                 ph_bcc          :: address_list,
-                ph_replyto      :: address_list
+                ph_replyto      :: address_list,
+                ph_date         :: maybe(string)
             ).
 
 :- type attach_info == scrollable(attachment).
@@ -619,10 +620,20 @@ create_edit_stage_2(Config, Screen, Headers0, Text0, UseAltHtmlFilter,
         Transition = screen_transition(not_sent, set_warning(Error))
     ).
 
+:- pred parse_date_header(header_value::in, maybe(string)::out) is det.
+
+parse_date_header(Date, ParsedDate) :-
+    ParsedDate0 = header_value_string(Date),
+    ( string.all_match(char.is_whitespace, ParsedDate0) ->
+        ParsedDate = no
+    ;
+        ParsedDate = yes(ParsedDate0)
+    ).
+
 :- pred make_parsed_headers(headers::in, parsed_headers::out) is det.
 
 make_parsed_headers(Headers, Parsed) :-
-    Headers = headers(_Date, From, To, Cc, Bcc, _Subject, ReplyTo,
+    Headers = headers(Date, From, To, Cc, Bcc, _Subject, ReplyTo,
         _References, _InReplyTo, _Rest),
 
     % [RFC 6854] allows group syntax in From - saves us work.
@@ -632,9 +643,10 @@ make_parsed_headers(Headers, Parsed) :-
     parse_address_list(Opt, header_value_string(Cc), ParsedCc),
     parse_address_list(Opt, header_value_string(Bcc), ParsedBcc),
     parse_address_list(Opt, header_value_string(ReplyTo), ParsedReplyTo),
+    parse_date_header(Date, ParsedDate),
 
     Parsed = parsed_headers(ParsedFrom, ParsedTo, ParsedCc, ParsedBcc,
-        ParsedReplyTo).
+        ParsedReplyTo, ParsedDate).
 
 :- pred call_editor(prog_config::in, string::in, call_res::out, io::di, io::uo)
     is det.
@@ -815,11 +827,12 @@ parse_and_expand_headers(Config, Headers0, Headers, Parsed, !IO) :-
     Expand(Cc0, Cc, ParsedCc, !IO),
     Expand(Bcc0, Bcc, ParsedBcc, !IO),
     Expand(ReplyTo0, ReplyTo, ParsedReplyTo, !IO),
+    parse_date_header(Date, ParsedDate),
 
     Headers = headers(Date, From, To, Cc, Bcc, Subject, ReplyTo,
         References, InReplyTo, Rest),
     Parsed = parsed_headers(ParsedFrom, ParsedTo, ParsedCc, ParsedBcc,
-        ParsedReplyTo).
+        ParsedReplyTo, ParsedDate).
 
 :- pred parse_and_expand_addresses(prog_config::in, quote_opt::in,
     header_value::in, header_value::out, address_list::out, io::di, io::uo)
@@ -2595,17 +2608,24 @@ get_addr_spec_in_mailbox(Mailbox, AddrSpec) :-
 make_headers(Prepare, Headers, ParsedHeaders, Date, MessageId, WriteHeaders) :-
     Headers = headers(_Date, _From, _To, _Cc, _Bcc, Subject, _ReplyTo,
         InReplyTo, References, RestHeaders),
-    ParsedHeaders = parsed_headers(From, To, Cc, Bcc, ReplyTo),
+    ParsedHeaders = parsed_headers(From, To, Cc, Bcc, ReplyTo, ExplicitDate),
     some [!Acc] (
         !:Acc = [],
         (
-            ( Prepare = prepare_send
-            ; Prepare = prepare_postpone
-            ),
-            cons(header(field_name("Date"), unstructured(Date, no_encoding)),
-                !Acc)
+            ExplicitDate = yes(DateValue0),
+            DateValue = unstructured(header_value(DateValue0), no_encoding),
+            cons(header(field_name("Date"), DateValue), !Acc)
         ;
-            Prepare = prepare_edit(_)
+            ExplicitDate = no,
+            (
+                ( Prepare = prepare_send
+                ; Prepare = prepare_postpone
+                ),
+                cons(header(field_name("Date"),
+                            unstructured(Date, no_encoding)), !Acc)
+            ;
+                Prepare = prepare_edit(_)
+            )
         ),
         (
             Prepare = prepare_send,

--- a/src/compose.m
+++ b/src/compose.m
@@ -1713,6 +1713,11 @@ draw_header_lines(Screen, !.Panels, Attrs, Headers, Parsed, Account,
     DrawRecv = draw_addresses(Attrs, show_crypto(yes, no), CryptoInfo),
     DrawSubj = draw_unstruct(Attrs),
     DrawRepl = draw_addresses(Attrs, show_crypto(no, no), CryptoInfo),
+    ( Parsed ^ ph_date = yes(ExplicitDate),
+      hdr(Screen, !Panels, Attrs, draw_unstruct(Attrs),
+          "    Date", header_value(ExplicitDate), !IO)
+    ; Parsed ^ ph_date = no
+    ),
     hdr(Screen, !Panels, Attrs, DrawFrom, "    From", Parsed ^ ph_from, !IO),
     hdr(Screen, !Panels, Attrs, DrawRecv, "      To", Parsed ^ ph_to, !IO),
     hdr(Screen, !Panels, Attrs, DrawRecv, "      Cc", Parsed ^ ph_cc, !IO),

--- a/src/compose.m
+++ b/src/compose.m
@@ -529,12 +529,19 @@ continue_from_message(Config, Crypto, Screen, ContinueBase, Message,
         CallRes, !IO),
     (
         CallRes = ok(String),
-        parse_message(String, HeadersB, _Body),
+        parse_message(String, HeadersB, _Body, PostponedMetadata),
         some [!Headers] (
             !:Headers = Headers0,
             !Headers ^ h_replyto := HeadersB ^ h_replyto,
             !Headers ^ h_inreplyto := HeadersB ^ h_inreplyto,
             !Headers ^ h_references := HeadersB ^ h_references,
+            ( ContinueBase = postponed_message ->
+                ( PostponedMetadata ^ retain_date = clear_date,
+                  !Headers ^ h_date := header_value("")
+                ;
+                  PostponedMetadata ^ retain_date = retain_date
+                )
+            ; true ),
             Headers = !.Headers
         ),
         (
@@ -600,7 +607,8 @@ create_edit_stage_2(Config, Screen, Headers0, Text0, UseAltHtmlFilter,
             ResEdit = ok,
             parse_message_file(Filename, ResParse, !IO),
             (
-                ResParse = ok(Headers1 - Text),
+                ResParse = ok(parsed_message(Headers1, Text,
+                                             _PostponedMetadata)),
                 io.remove_file(Filename, _, !IO),
                 update_references(Headers0, Headers1, Headers2),
                 reenter_staging_screen(Config, Screen, Headers2, Text,
@@ -2638,9 +2646,24 @@ make_headers(Prepare, Headers, ParsedHeaders, Date, MessageId, WriteHeaders) :-
                 unstructured(wrap_angle_brackets(MessageId), no_encoding)),
                 !Acc)
         ;
-            ( Prepare = prepare_edit(_)
-            ; Prepare = prepare_postpone
-            )
+            Prepare = prepare_postpone,
+            ( ParsedHeaders ^ ph_date = yes(_) ->
+              RetainDate = retain_date
+            ; RetainDate = clear_date ),
+            (
+                % This is a simple and straightforward solution for
+                % setting a single metadata value if needed. Should any
+                % other metadata values be added later, this code would
+                % need to be adjusted accordingly.
+                RetainDate = retain_date
+            ->
+                Metadata = "retain_date",
+                cons(header(field_name("X-Bower-Metadata"),
+                            unstructured(header_value(Metadata),
+                            no_encoding)), !Acc)
+            ; true )
+        ;
+            Prepare = prepare_edit(_)
         ),
         (
             ( Prepare = prepare_send

--- a/src/data.m
+++ b/src/data.m
@@ -70,6 +70,13 @@
 :- type message_part_id
     --->    message_part_id(message_id, part_id).
 
+:- type parsed_message
+    --->    parsed_message(
+                headers         :: headers,
+                body            :: string,
+                metadata        :: postponed_metadata
+            ).
+
 :- type headers
     --->    headers(
                 % Technically, header fields.
@@ -93,6 +100,15 @@
     ;       decoded_unstructured(string).
             % An unstructured field that may contain RFC 2047 encoded-words,
             % which we keep in decoded form.
+
+:- type postponed_metadata
+    --->    postponed_metadata(
+                retain_date     :: pm_retain_date
+            ).
+
+:- type pm_retain_date
+    --->    retain_date;
+            clear_date.
 
 :- type tag
     --->    tag(string).

--- a/src/message_file.m
+++ b/src/message_file.m
@@ -186,8 +186,7 @@ add_standard_header(Name, Value, !Headers) :-
     ; strcase_equal(Name, "References") ->
         !Headers ^ h_references := Value
     ; strcase_equal(Name, "Date") ->
-        % Ignore it.
-        true
+        !Headers ^ h_date := Value
     ; strcase_equal(Name, "Message-ID") ->
         % Ignore it.
         true


### PR DESCRIPTION
Previously, the date field was always updated when sending the
message. While this behaviour is quite reasonable in most cases,
there might also be moments when specifying a date different from
the system's current local time might come in handy. As it happens,
I was just in need of this ability myself at this very moment; hence
I implemented this feature. I would be happy if this feature made it
into mainline bower. While its use is probably a rare corner case, the
feature itself is quite non-intrusive and does not change the behaviour
of bower unless a user explicitly adds a date header to the temporary
message. Consequently, its existence should be mostly transparent to
those who might not want or need it.

As already mentioned, this patchset introduces the ability to manually
override the date field. This is done by simply adding a 'Date' header
when composing a message. Once this header is added, bower will use the
user-specified date value instead of automatically generating one from
the current system's time settings. With the last commit, this behaviour
is even persisted across the postpone-resume cycle. To return to the
automated setting of the message date, a user would only need to remove
the date value (or the whole line) when editing the message. If a user
does not manually add a date header line at some point, the changes
introduced in this patchset should not affect their usage of bower at
all. The feature is not (yet) documented, but I believe that it is quite
straightforward; it was even the first thing I tried to do myself before
(disappointedly) realising that the date value is always overridden with
the system's current local time.

## Drawbacks / Open issues

* In order to persist the information on whether a date value was set
  automatically or manually, a new header field was introduced. This
  field is called 'X-Bower-Metadata' and is handled as a special case when
  parsing messages. When parsing postponed messages, the existence of and
  information in X-Bower-Metadata will be used to indicate whether the
  date value should be retained or whether it should be cleared. While
  I believe that having this field for persisting information across the
  postpone-resume-cycle comes in handy, its design was pretty ad-hoc and
  the implementation probably still has a number of rough edges that
  would need to be resolved if the field should ever be used for more
  than storing a single boolean value. Having said that, the field is
  currently designed as a simple semicolon-separated list of strings
  that might have some kind of special meaning for bower. This should
  make the design both reasonably flexible and reasonably simple for
  further extensions.
* The use of this patchset made another issue apparent: When a message
  is resumed, edited, saved without modification and then postponed
  again, it disappears. This is apparently due to the fact that notmuch
  will treat the *new* version as a duplicate of the *old* one, while
  bower, having inserted the *new* version, marks the *old* version
  as deleted. As, prior to the introduction of manual overrides, the
  date of postponed messages was always updated upon insertion into the
  notmuch database, the case where two messages have both the same date
  and the same contents did not come up in actual usage. While this bug
  is annoying, however, I do not believe that the proposed patchset is to
  blame for it. Currently, my personal solution for dealing with this bug
  is to take special care when postponing messages containing manual date
  overrides; and to search the messages marked as deleted when I forget.