### PR TITLE
Use a unicode-aware count function for string wrapping

### DIFF
--- a/src/pager_text.m
+++ b/src/pager_text.m
@@ -87,8 +87,9 @@ append_text(Max, String, Start, LastBreak, Cur, !Context, !Lines) :-
             append_text(Max, String, Start, Cur, Next, !Context, !Lines)
         ;
             % Wrap long lines.
-            % XXX this should actually count with wcwidth
-            Next - Start > Max
+            string.unsafe_between(String, Start, Next, SubString),
+            string.count_codepoints(SubString, SubStringLength),
+            SubStringLength > Max
         ->
             maybe_append_substring(String, Start, LastBreak, !Context, !Lines),
             skip_whitespace(String, LastBreak, NextStart),


### PR DESCRIPTION
The wrapping functionality previously counted the number of bytes
in a string when determining whether or not to wrap a line. As the
todo-comment right above already stated, this obviously breaks line
wrapping for character encodings that might use more than a single
byte to encode a character. More specifically, it also breaks line
wrapping for the w3m dumps of The Register's On Call column that
are delivered to my email inbox every Saturday, since these often
contain unicode quotation marks which use up to three bytes each.
Using the unicode-aware count_codepoints predicate to determine
line lengths solves the issue.