### PR TITLE
Fix build failure with GCC-14

### DIFF
--- a/src/Mercury.options
+++ b/src/Mercury.options
@@ -6,7 +6,7 @@ GRADE = hlc.gc
 MCFLAGS += --grade $(GRADE)
 
 # Link with curses.
-MLLIBS-bower += -lncursesw -lpanelw
+MLLIBS-bower += -lncursesw -lpanelw -ltinfo
 
 # Build with gpgme.
 CFLAGS += -D_FILE_OFFSET_BITS=64

--- a/src/curs.m
+++ b/src/curs.m
@@ -768,6 +768,7 @@ soft_suspend(Pred, Res, !IO) :-
 "
     wint_t ch;
     int rc;
+    extern int get_wch(wint_t *wch);
 
     rc = get_wch(&ch);
     if (rc == OK) {


### PR DESCRIPTION
I dunno why includes don't propagate to this function. I don't know Mercury. I find simplest method to fix it to be re-declaring function with correct signature.
Also added linking flag to fix link-time failure found after first error was cleared.

Closes #119 possibly badly